### PR TITLE
FIX: show-page wont crash if no user is signed in

### DIFF
--- a/app/views/ingredients/show.html.erb
+++ b/app/views/ingredients/show.html.erb
@@ -16,12 +16,13 @@
     <% end %>
   </div>
 
-<% if current_user.verified  %>
-  <div class="container">
-    <%= render partial: 'ingredient_reviews/form' %>
-  </div>
-
+<% if current_user %>
+  <% if current_user.verified  %>
+    <div class="container">
+      <%= render partial: 'ingredient_reviews/form' %>
+    </div>
   <% end %>
+<% end %>
 
 <%= link_to "Take me home", root_path, class:"btn-primary" %>
 <%= link_to "back to product search", products_path, class:"btn-primary" %>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -8,10 +8,13 @@
   <p>Skin concern: <%= product_review.skin_concern %></p>
   <p>Rating: <%= product_review.product_rating %></p>
   <p>Review by: <%= product_review.user.username %></p>
-
 </div>
 <% end %>
 
+<% if current_user %>
   <div class="container">
     <%= render partial: 'product_reviews/form' %>
   </div>
+<% end %>
+</div>
+


### PR DESCRIPTION
Small fix: show page for ingredient and product wont crash if no user is signed in.