### PR TITLE
changed file path for jquery.raty.js in application.js

### DIFF
--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -8,7 +8,7 @@ require("turbolinks").start()
 require("@rails/activestorage").start()
 require("channels")
 require("jquery")
-require("jquery.raty.js")
+require("./jquery.raty.js")
 // Uncomment to copy all static images under ../images to the output folder and reference
 // them with the image_pack_tag helper in views (e.g <%= image_pack_tag 'rails.png' %>)
 // or the `imagePath` JavaScript helper below.


### PR DESCRIPTION
The difference between require and require relative in ruby is that require is for libraries, require relative is for object

in Javascript both use require so you need to add ./ to make it relative otherwise it requires it as a library